### PR TITLE
Remove staging urls.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+.vscode

--- a/constants.json
+++ b/constants.json
@@ -1,6 +1,5 @@
 {
   "comments": {
-    "staging": "Deploy preview for *web-dev-staging* ready!",
     "reviewbot": "reviewbot-automated-comment",
     "dev": "reviewbot-dev"
   },


### PR DESCRIPTION
I think this may have broken at some point (I don't see the bot commenting with these urls anymore). But since we're moving to Firebase previews it means we can't easily generate these because firebase puts a random hash on the end of the preview url. So, for now, we're removing this feature.